### PR TITLE
Don't use gPA cache except when using mempool

### DIFF
--- a/transaction-relayer/src/db_service.rs
+++ b/transaction-relayer/src/db_service.rs
@@ -1,4 +1,4 @@
-use duckdb::{params, Connection};
+use duckdb::{params, Connection, Error};
 use jito_core::immutable_deserialized_packet::ImmutableDeserializedPacket;
 use log::{error, info};
 use std::net::SocketAddr::V4;


### PR DESCRIPTION
This should eliminate gPA calls from the relayer during transaction scoring operation.  We don't use OFAC functionality, and we can turn off the cache refresh when not using the mempool.

---

Testing locally, and on EXP validator.